### PR TITLE
[FEAT] 프로필 이미지 null 값이 아닌 빈 값으로 보내기

### DIFF
--- a/app/src/main/java/com/starters/yeogida/data/api/UserService.kt
+++ b/app/src/main/java/com/starters/yeogida/data/api/UserService.kt
@@ -14,7 +14,7 @@ interface UserService {
     @Multipart
     @POST("members/join")
     suspend fun addUser(
-        @Part imgUrl: MultipartBody.Part?,
+        @Part imgUrl: MultipartBody.Part,
         @PartMap memberJoinRequest: HashMap<String, RequestBody>
     ): Response<BaseResponse<SignUpResponseData>>
 

--- a/app/src/main/java/com/starters/yeogida/util/ImageUtil.kt
+++ b/app/src/main/java/com/starters/yeogida/util/ImageUtil.kt
@@ -1,0 +1,78 @@
+package com.starters.yeogida.util
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.media.ExifInterface
+import android.net.Uri
+import java.io.File
+
+object ImageUtil {
+    /**
+     * 이미지 회전 데이터 반환
+     */
+    private fun getExifDegrees(ei: ExifInterface): Float {
+        val orientation: Int =
+            ei.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
+        return when (orientation) {
+            ExifInterface.ORIENTATION_ROTATE_90 -> 90f
+            ExifInterface.ORIENTATION_ROTATE_180 -> 180f
+            ExifInterface.ORIENTATION_ROTATE_270 -> 270f
+            else -> 0f
+        }
+    }
+
+    fun getResizePicture(context: Context, imgUri: Uri): File? {
+        val contentResolver = context.contentResolver
+        var imageFile: File? = null
+
+        val fileName = ""
+
+        //1)회전할 각도 구하기
+        var degrees = 0f
+        contentResolver.openInputStream(imgUri)?.use { inputStream ->
+            degrees = getExifDegrees(ExifInterface(inputStream))
+        }
+
+        //2)Resizing 할 BitmapOption 만들기
+        val bmOptions = BitmapFactory.Options().apply {
+            // Get the dimensions of the bitmap
+            inJustDecodeBounds = true
+            contentResolver.openInputStream(imgUri)?.use { inputStream ->
+                //get img dimension
+                BitmapFactory.decodeStream(inputStream, null, this)
+            }
+
+            // Determine how much to scale down the image
+            val targetW: Int = 1000 //in pixel
+            val targetH: Int = 1000 //in pixel
+            val scaleFactor: Int = Math.min(outWidth / targetW, outHeight / targetH)
+
+            // Decode the image file into a Bitmap sized to fill the View
+            inJustDecodeBounds = false
+            inSampleSize = scaleFactor
+        }
+
+        //3) Bitmap 생성 및 셋팅 (resized + rotated)
+        contentResolver.openInputStream(imgUri)?.use { inputStream ->
+            BitmapFactory.decodeStream(inputStream, null, bmOptions)?.also { bitmap ->
+                val matrix = Matrix()
+                matrix.preRotate(degrees, 0f, 0f)
+
+                val resizedBitmap =
+                    Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, false)
+
+                val compressedUri = UriUtil.bitmapToUri(context, resizedBitmap, fileName)
+
+                compressedUri?.let { compressedUri ->
+                    imageFile = UriUtil.toFile(context, compressedUri)
+                    contentResolver.delete(compressedUri, null, null)   // Uri에 해당되는 값 갤러리에서 제거.
+
+                    return imageFile
+                }
+            }
+        }
+        return imageFile
+    }
+}


### PR DESCRIPTION
## 💡 관련 이슈
close #61 <!--close #이슈넘버-->

## 🌱 변경 사항 및 이유
- 프로필 이미지를 보내지 않을 때, null 값을 보냈는데 빈 값의 MultiPart 값을 전송하는 것으로 변경 <!--변경사항 적기-->
- getResizePicture() 함수를 새로 생성한 ImageUtil로 이동

## ✅ PR Point
<!--리뷰에 중점이 될 포인트 요소들 적기-->
- getResizePicture() 함수의 경우, 이미지를 압축하는 기능을 하는 함수로, 다른 곳에서도 사용할 것 같아서 Util로 이동함
- MultiPart 의 빈 파일을 전송하는 방법
```KOTLIN
val requestFile = imageFile?.asRequestBody("image/*".toMediaTypeOrNull())
                ?: "".toRequestBody("text/plain".toMediaTypeOrNull())

val partImg = MultipartBody.Part.createFormData(
                "imgUrl", imageFile?.name ?: "", requestFile
            )
```


