### PR TITLE
[FIX] 이미지 권한 버그

### DIFF
--- a/app/src/main/java/com/starters/yeogida/DataStoreModule.kt
+++ b/app/src/main/java/com/starters/yeogida/DataStoreModule.kt
@@ -18,6 +18,8 @@ class DataStoreModule(private val context: Context) {
     private val USER_REFRESH_TOKEN_KEY = stringPreferencesKey("USER_REFRESH_TOKEN")
     private val USER_BEARER_TOKEN_KEY = stringPreferencesKey("USER_BEARER_TOKEN")
     private val USER_IS_LOGIN_KEY = booleanPreferencesKey("USER_IS_LOGIN")
+    private val IMAGE_PERMISSION_IS_REJECTED_KEY =
+        booleanPreferencesKey("IS_IMAGE_PERMISSION_REJECTED")
 
     val userAccessToken: Flow<String> = context.userDataStore.data
         .catch { exception ->
@@ -67,6 +69,18 @@ class DataStoreModule(private val context: Context) {
             userPrefs[USER_IS_LOGIN_KEY] ?: false
         }
 
+    val imagePermissionIsRejected: Flow<Boolean> = context.userDataStore.data
+        .catch { exception ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { userPrefs ->
+            userPrefs[IMAGE_PERMISSION_IS_REJECTED_KEY] ?: false
+        }
+
     private suspend fun saveAccessToken(accessToken: String) {
         context.userDataStore.edit { userPrefs ->
             userPrefs[USER_ACCESS_TOKEN_KEY] = accessToken
@@ -106,6 +120,12 @@ class DataStoreModule(private val context: Context) {
     suspend fun saveIsLogin(userIsLogin: Boolean) {
         context.userDataStore.edit { userPrefs ->
             userPrefs[USER_IS_LOGIN_KEY] = userIsLogin
+        }
+    }
+
+    suspend fun saveIsImgPermissionRejected(isRejected: Boolean) {
+        context.userDataStore.edit { userPrefs ->
+            userPrefs[IMAGE_PERMISSION_IS_REJECTED_KEY] = isRejected
         }
     }
 

--- a/app/src/main/java/com/starters/yeogida/presentation/user/JoinActivity.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/user/JoinActivity.kt
@@ -179,6 +179,7 @@ class JoinActivity : AppCompatActivity() {
                     ) == PackageManager.PERMISSION_GRANTED -> {
                         withContext(Dispatchers.Main) {
                             navigatePhotos()
+                            dataStore.saveIsImgPermissionRejected(false)
                         }
                         Log.i("BUTTON", "navigate")
                     }

--- a/app/src/main/java/com/starters/yeogida/presentation/user/JoinActivity.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/user/JoinActivity.kt
@@ -66,7 +66,7 @@ class JoinActivity : AppCompatActivity() {
 
     private val PERMISSION_ALBUM = 101
     private val REQUEST_STORAGE = 1000
-    private var permissionRejectCount = 0
+
     private var imageFile: File? = null
 
     private val imageResult = registerForActivityResult(
@@ -143,9 +143,6 @@ class JoinActivity : AppCompatActivity() {
                     navigatePhotos()
                 } else if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_DENIED) {
                     Toast.makeText(this, "권한을 거부하였습니다.", Toast.LENGTH_SHORT).show()
-                    if (permissionRejectCount == 0) {
-                        permissionRejectCount++
-                    }
                 } else {
 
                 }
@@ -156,8 +153,8 @@ class JoinActivity : AppCompatActivity() {
                     navigatePhotos()
                 } else if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_DENIED) {
                     Toast.makeText(this, "권한을 거부하였습니다.", Toast.LENGTH_SHORT).show()
-                    if (permissionRejectCount == 1) {
-                        permissionRejectCount++
+                    CoroutineScope(Dispatchers.IO).launch {
+                        dataStore.saveIsImgPermissionRejected(true)
                     }
                 }
             }
@@ -172,29 +169,43 @@ class JoinActivity : AppCompatActivity() {
         joinViewModel.startGalleryEvent.observe(this) {
             Log.i("BUTTON", "initAdd")
 
-            when {
-                ContextCompat.checkSelfPermission(
-                    this,
-                    READ_EXTERNAL_STORAGE
-                ) == PackageManager.PERMISSION_GRANTED -> {
-                    navigatePhotos()
-                    Log.i("BUTTON", "navigate")
-                }
+            CoroutineScope(Dispatchers.IO).launch {
+                val isRejected = dataStore.imagePermissionIsRejected.first()
 
-                shouldShowRequestPermissionRationale(READ_EXTERNAL_STORAGE) -> {
-                    showPermissionContextPopup(this)
-                    Log.i("BUTTON", "showpermission")
-                }
+                when {
+                    ContextCompat.checkSelfPermission(
+                        this@JoinActivity,
+                        READ_EXTERNAL_STORAGE
+                    ) == PackageManager.PERMISSION_GRANTED -> {
+                        withContext(Dispatchers.Main) {
+                            navigatePhotos()
+                        }
+                        Log.i("BUTTON", "navigate")
+                    }
 
-                permissionRejectCount == 2 -> {
-                    showSettingDialog(this)
-                }
+                    isRejected -> {
+                        withContext(Dispatchers.Main) {
+                            showSettingDialog(this@JoinActivity)
+                        }
+                    }
 
-                else -> {
-                    requestPermissions(arrayOf(READ_EXTERNAL_STORAGE), REQUEST_STORAGE)
-                    Log.i("BUTTON", "else")
+                    shouldShowRequestPermissionRationale(READ_EXTERNAL_STORAGE) -> {
+                        withContext(Dispatchers.Main) {
+                            showPermissionContextPopup(this@JoinActivity)
+                        }
+                        Log.i("BUTTON", "showpermission")
+                    }
+
+
+                    else -> {
+                        withContext(Dispatchers.Main) {
+                            requestPermissions(arrayOf(READ_EXTERNAL_STORAGE), REQUEST_STORAGE)
+                        }
+                        Log.i("BUTTON", "else")
+                    }
                 }
             }
+
         }
     }
 


### PR DESCRIPTION

## 💡 관련 이슈
close #70 <!--close #이슈넘버-->

## 🌱 변경 사항 및 이유
- Activity의 권한 거절확인 값을 DataStore로 이동 <!--변경사항 적기-->

## ✅ PR Point
<!--리뷰에 중점이 될 포인트 요소들 적기-->
- Activity의 값은 App을 껐다 켰을 때, 값이 초기화되어 권한 처리가 안되어서, DataStore 값으로 설정하도록 바꾸었습니다.

## ❗️ 참고 사항
<!--다른 개발자들이 참고했으면 하는 사항-->
- 나중에라도 로그인 시작할떄나 회원가입을 완료할 때 ProgressBar를 적용하면 좋을 것 같습니다.
<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
