### PR TITLE
[FEAT] 장소 둘러보기

### DIFF
--- a/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
@@ -11,6 +11,8 @@ import androidx.navigation.fragment.findNavController
 import com.starters.yeogida.R
 import com.starters.yeogida.data.local.PlaceData
 import com.starters.yeogida.databinding.FragmentAroundPlaceBinding
+import com.starters.yeogida.presentation.place.PlaceActivity
+import com.starters.yeogida.presentation.trip.AddTripActivity
 
 class AroundPlaceFragment : Fragment() {
     private lateinit var binding: FragmentAroundPlaceBinding
@@ -59,5 +61,9 @@ class AroundPlaceFragment : Fragment() {
 
     fun moveToPlaceMap(view: View) {
         findNavController().navigate(R.id.action_aroundPlace_to_placeMap)
+    }
+
+    fun close(view: View) {
+        (activity as PlaceActivity).finish()
     }
 }

--- a/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
@@ -8,11 +8,13 @@ import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearSmoothScroller
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.SmoothScroller
 import com.starters.yeogida.R
 import com.starters.yeogida.data.local.PlaceData
 import com.starters.yeogida.databinding.FragmentAroundPlaceBinding
 import com.starters.yeogida.presentation.place.PlaceActivity
-import com.starters.yeogida.presentation.trip.AddTripActivity
 
 class AroundPlaceFragment : Fragment() {
     private lateinit var binding: FragmentAroundPlaceBinding
@@ -47,6 +49,24 @@ class AroundPlaceFragment : Fragment() {
                 PlaceData("https://cdn.pixabay.com/photo/2017/08/07/23/11/iceland-2608985_1280.jpg", "오오폭포", "3.0", 0, "바"),
                 PlaceData("https://cdn.pixabay.com/photo/2016/04/26/03/55/salmon-1353598_1280.jpg", "연어맛집", "4.5", 30, "쇼핑"),
                 PlaceData("https://cdn.pixabay.com/photo/2013/04/11/19/46/building-102840_1280.jpg", "박물관", "2.0", 1, "숙소"),
+                PlaceData("https://cdn.pixabay.com/photo/2017/08/07/23/11/iceland-2608985_1280.jpg", "오오폭포", "3.0", 0, "기타"),
+                PlaceData("https://cdn.pixabay.com/photo/2016/04/26/03/55/salmon-1353598_1280.jpg", "연어맛집", "4.5", 30, "식당"),
+                PlaceData("https://cdn.pixabay.com/photo/2013/04/11/19/46/building-102840_1280.jpg", "박물관", "2.0", 1, "카페"),
+                PlaceData("https://cdn.pixabay.com/photo/2017/08/07/23/11/iceland-2608985_1280.jpg", "오오폭포", "3.0", 0, "바"),
+                PlaceData("https://cdn.pixabay.com/photo/2016/11/21/13/04/alcoholic-beverages-1845295_1280.jpg", "수울수울", "1.5", 999, "관광지"),
+                PlaceData("https://cdn.pixabay.com/photo/2013/04/11/19/46/building-102840_1280.jpg", "박물관", "2.0", 1, "카페"),
+                PlaceData("https://cdn.pixabay.com/photo/2017/08/07/23/11/iceland-2608985_1280.jpg", "오오폭포", "3.0", 0, "바"),
+                PlaceData("https://cdn.pixabay.com/photo/2016/04/26/03/55/salmon-1353598_1280.jpg", "연어맛집", "4.5", 30, "쇼핑"),
+                PlaceData("https://cdn.pixabay.com/photo/2013/04/11/19/46/building-102840_1280.jpg", "박물관", "2.0", 1, "숙소"),
+                PlaceData("https://cdn.pixabay.com/photo/2017/08/07/23/11/iceland-2608985_1280.jpg", "오오폭포", "3.0", 0, "기타"),
+                PlaceData("https://cdn.pixabay.com/photo/2016/04/26/03/55/salmon-1353598_1280.jpg", "연어맛집", "4.5", 30, "식당"),
+                PlaceData("https://cdn.pixabay.com/photo/2013/04/11/19/46/building-102840_1280.jpg", "박물관", "2.0", 1, "카페"),
+                PlaceData("https://cdn.pixabay.com/photo/2017/08/07/23/11/iceland-2608985_1280.jpg", "오오폭포", "3.0", 0, "바"),
+                PlaceData("https://cdn.pixabay.com/photo/2016/11/21/13/04/alcoholic-beverages-1845295_1280.jpg", "수울수울", "1.5", 999, "관광지"),
+                PlaceData("https://cdn.pixabay.com/photo/2013/04/11/19/46/building-102840_1280.jpg", "박물관", "2.0", 1, "카페"),
+                PlaceData("https://cdn.pixabay.com/photo/2017/08/07/23/11/iceland-2608985_1280.jpg", "오오폭포", "3.0", 0, "바"),
+                PlaceData("https://cdn.pixabay.com/photo/2016/04/26/03/55/salmon-1353598_1280.jpg", "연어맛집", "4.5", 30, "쇼핑"),
+                PlaceData("https://cdn.pixabay.com/photo/2013/04/11/19/46/building-102840_1280.jpg", "박물관", "2.0", 1, "숙소"),
                 PlaceData("https://cdn.pixabay.com/photo/2017/08/07/23/11/iceland-2608985_1280.jpg", "오오폭포", "3.0", 0, "기타")
             )
         )
@@ -61,6 +81,19 @@ class AroundPlaceFragment : Fragment() {
 
     fun moveToPlaceMap(view: View) {
         findNavController().navigate(R.id.action_aroundPlace_to_placeMap)
+    }
+
+    fun RecyclerView.smoothSnapToPosition(position: Int, snapMode: Int = LinearSmoothScroller.SNAP_TO_START) {
+        val smoothScroller = object : LinearSmoothScroller(this.context) {
+            override fun getVerticalSnapPreference(): Int = snapMode
+            override fun getHorizontalSnapPreference(): Int = snapMode
+        }
+        smoothScroller.targetPosition = position
+        layoutManager?.startSmoothScroll(smoothScroller)
+    }
+
+    fun moveToTop(view: View) {
+        binding.scrollViewAroundPlace.smoothScrollTo(0, 0)
     }
 
     fun close(view: View) {

--- a/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
@@ -22,6 +22,7 @@ class AroundPlaceFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_around_place, container, false)
+        binding.view = this
         return binding.root
     }
 
@@ -51,12 +52,12 @@ class AroundPlaceFragment : Fragment() {
     }
 
     private fun initNavigation() {
-        binding.ivAroundPlaceMap.setOnClickListener {
-            findNavController().navigate(R.id.action_around_place_to_around_place_map)
-        }
-
         viewModel.openPlaceDetailEvent.observe(viewLifecycleOwner) {
             findNavController().navigate(R.id.action_aroundPlace_to_placeDetail)
         }
+    }
+
+    fun moveToPlaceMap(view: View) {
+        findNavController().navigate(R.id.action_aroundPlace_to_placeMap)
     }
 }

--- a/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceMapFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceMapFragment.kt
@@ -4,7 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.MapView
@@ -12,6 +14,7 @@ import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
+import com.starters.yeogida.R
 import com.starters.yeogida.databinding.FragmentAroundPlaceMapBinding
 
 class AroundPlaceMapFragment : Fragment(), OnMapReadyCallback, GoogleMap.OnMarkerClickListener {
@@ -24,7 +27,8 @@ class AroundPlaceMapFragment : Fragment(), OnMapReadyCallback, GoogleMap.OnMarke
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentAroundPlaceMapBinding.inflate(inflater, container, false)
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_around_place_map, container, false)
+        binding.view = this
 
         mView = binding.mapViewAroundPlace
         mView.onCreate(savedInstanceState)
@@ -80,5 +84,9 @@ class AroundPlaceMapFragment : Fragment(), OnMapReadyCallback, GoogleMap.OnMarke
     override fun onDestroy() {
         mView.onDestroy()
         super.onDestroy()
+    }
+
+    fun close(view: View) {
+        findNavController().navigateUp()
     }
 }

--- a/app/src/main/java/com/starters/yeogida/presentation/trip/AddTripFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/trip/AddTripFragment.kt
@@ -108,6 +108,7 @@ class AddTripFragment : Fragment() {
     fun moveToAroundPlace(view: View) {
         val intent = Intent(activity, PlaceActivity::class.java)
         startActivity(intent)
+        (activity as AddTripActivity).finish()
     }
 
     // 갤러리 창 연결

--- a/app/src/main/java/com/starters/yeogida/presentation/trip/AddTripFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/trip/AddTripFragment.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -14,11 +13,11 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.widget.addTextChangedListener
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
 import com.starters.yeogida.R
 import com.starters.yeogida.databinding.FragmentAddTripBinding
 import com.starters.yeogida.presentation.common.ImageActivity
+import com.starters.yeogida.presentation.place.PlaceActivity
 import com.starters.yeogida.util.shortToast
 
 class AddTripFragment : Fragment() {
@@ -107,7 +106,8 @@ class AddTripFragment : Fragment() {
         }
 
     fun moveToAroundPlace(view: View) {
-        findNavController().navigate(R.id.action_add_trip_to_around_place)
+        val intent = Intent(activity, PlaceActivity::class.java)
+        startActivity(intent)
     }
 
     // 갤러리 창 연결

--- a/app/src/main/res/layout/fragment_around_place.xml
+++ b/app/src/main/res/layout/fragment_around_place.xml
@@ -32,6 +32,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="4dp"
+                    android:onClick="@{view::close}"
                     android:padding="12dp"
                     android:src="@drawable/ic_back" />
 

--- a/app/src/main/res/layout/fragment_around_place.xml
+++ b/app/src/main/res/layout/fragment_around_place.xml
@@ -4,6 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <variable
+            name="view"
+            type="com.starters.yeogida.presentation.around.AroundPlaceFragment" />
 
     </data>
 
@@ -48,6 +51,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="end"
                     android:layout_marginEnd="4dp"
+                    android:onClick="@{view::moveToPlaceMap}"
                     android:padding="12dp"
                     android:src="@drawable/ic_map" />
 
@@ -238,7 +242,7 @@
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/rv_around_place"
-                    android:visibility="gone"
+
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_marginTop="16dp"
@@ -251,7 +255,6 @@
                     tools:listitem="@layout/item_place" />
 
                 <LinearLayout
-                    android:visibility="gone"
                     android:background="@drawable/rectangle_fill_gray100_17"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -292,6 +295,7 @@
         </androidx.core.widget.NestedScrollView>
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:visibility="gone"
             android:id="@+id/layout_around_place_empty"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_around_place.xml
+++ b/app/src/main/res/layout/fragment_around_place.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="view"
             type="com.starters.yeogida.presentation.around.AroundPlaceFragment" />
@@ -61,6 +62,7 @@
         </com.google.android.material.appbar.AppBarLayout>
 
         <androidx.core.widget.NestedScrollView
+            android:id="@+id/scrollView_around_place"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
@@ -243,7 +245,6 @@
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/rv_around_place"
-
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_marginTop="16dp"
@@ -256,38 +257,38 @@
                     tools:listitem="@layout/item_place" />
 
                 <LinearLayout
-                    android:background="@drawable/rectangle_fill_gray100_17"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
                     android:id="@+id/layout_around_place_top"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="bottom|center"
                     android:layout_marginBottom="24dp"
+                    android:background="@drawable/rectangle_fill_gray100_17"
+                    android:onClick="@{view::moveToTop}"
+                    android:orientation="horizontal"
                     android:paddingStart="16dp"
-                    android:paddingEnd="12dp"
                     android:paddingTop="8dp"
+                    android:paddingEnd="12dp"
                     android:paddingBottom="8dp"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    android:orientation="horizontal">
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent">
 
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/around_place_top"
-                        android:textSize="16sp"
                         android:layout_gravity="center"
                         android:fontFamily="@font/noto_sans_regular"
-                        android:textColor="@color/black"
-                        android:gravity="center"/>
+                        android:gravity="center"
+                        android:text="@string/around_place_top"
+                        android:textColor="@color/black" />
 
                     <ImageView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
                         android:minWidth="0dp"
                         android:minHeight="0dp"
-                        android:layout_width="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_height="wrap_content"
-                        android:src="@drawable/ic_up"/>
+                        android:src="@drawable/ic_up" />
 
                 </LinearLayout>
 
@@ -296,42 +297,42 @@
         </androidx.core.widget.NestedScrollView>
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:visibility="gone"
             android:id="@+id/layout_around_place_empty"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
             android:layout_gravity="center"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/scroll_view_around_place_tag">
 
             <ImageView
                 android:id="@+id/iv_around_place_empty"
                 android:layout_width="0dp"
+                android:layout_height="0dp"
                 android:layout_marginStart="80dp"
                 android:layout_marginEnd="80dp"
-                android:layout_height="0dp"
-                app:layout_constraintDimensionRatio="1:1"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
                 android:src="@drawable/ic_sad"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintDimensionRatio="1:1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
                 app:tint="@color/main_blue" />
 
             <TextView
                 android:id="@+id/tv_around_place_empty"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/around_place_empty"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
                 android:layout_marginTop="24dp"
-                android:textColor="@color/black"
-                android:textSize="18sp"
                 android:fontFamily="@font/noto_sans_regular"
                 android:gravity="center"
-                app:layout_constraintTop_toBottomOf="@id/iv_around_place_empty"/>
+                android:text="@string/around_place_empty"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/iv_around_place_empty" />
 
 
         </androidx.constraintlayout.widget.ConstraintLayout>
@@ -341,11 +342,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end|bottom"
+            android:layout_margin="24dp"
             android:src="@drawable/ic_plus_blue"
-            app:tint="@null"
             app:backgroundTint="@color/white_blue"
             app:elevation="0dp"
-            android:layout_margin="24dp"/>
+            app:tint="@null" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_around_place_map.xml
+++ b/app/src/main/res/layout/fragment_around_place_map.xml
@@ -1,57 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".presentation.around.AroundPlaceMapFragment">
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="view"
+            type="com.starters.yeogida.presentation.around.AroundPlaceMapFragment" />
+    </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:id="@+id/layout_around_place_map_title"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:layout_height="match_parent"
+        tools:context=".presentation.around.AroundPlaceMapFragment">
 
-        <ImageView
-            android:id="@+id/iv_around_place_map_back"
-            android:layout_width="wrap_content"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_around_place_map_title"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:layout_gravity="center"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:layout_marginBottom="8dp"
-            android:layout_marginStart="4dp"
-            android:padding="12dp"
-            android:src="@drawable/ic_back"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/tv_around_place_map_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:fontFamily="@font/noto_sans_regular"
-            android:textColor="@color/black"
-            android:textSize="18sp"
-            app:layout_constraintBottom_toBottomOf="@id/iv_around_place_map_back"
+            android:orientation="horizontal"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/iv_around_place_map_back"
-            tools:text="단양 둘러보기" />
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/iv_around_place_map_back"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginStart="4dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
+                android:padding="12dp"
+                android:onClick="@{view::close}"
+                android:src="@drawable/ic_back"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/tv_around_place_map_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:fontFamily="@font/noto_sans_regular"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                app:layout_constraintBottom_toBottomOf="@id/iv_around_place_map_back"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@id/iv_around_place_map_back"
+                tools:text="단양 둘러보기" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <com.google.android.gms.maps.MapView
+            android:id="@+id/mapView_around_place"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layout_around_place_map_title" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <com.google.android.gms.maps.MapView
-        android:id="@+id/mapView_around_place"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/layout_around_place_map_title"
-        app:layout_constraintBottom_toBottomOf="parent" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/navigation/nav_add_trip.xml
+++ b/app/src/main/res/navigation/nav_add_trip.xml
@@ -9,23 +9,5 @@
         android:id="@+id/navigation_add_trip"
         android:name="com.starters.yeogida.presentation.trip.AddTripFragment"
         android:label="AddTripFragment"
-        tools:layout="@layout/fragment_add_trip">
-        <action
-            android:id="@+id/action_add_trip_to_around_place"
-            app:destination="@id/navigation_around_place" />
-    </fragment>
-    <fragment
-        android:id="@+id/navigation_around_place"
-        android:name="com.starters.yeogida.presentation.around.AroundPlaceFragment"
-        android:label="AroundPlaceFragment"
-        tools:layout="@layout/fragment_around_place">
-        <action
-            android:id="@+id/action_around_place_to_around_place_map"
-            app:destination="@id/navigation_around_place_map" />
-    </fragment>
-    <fragment
-        android:id="@+id/navigation_around_place_map"
-        android:name="com.starters.yeogida.presentation.around.AroundPlaceMapFragment"
-        android:label="fragment_around_place_map"
-        tools:layout="@layout/fragment_around_place_map" />
+        tools:layout="@layout/fragment_add_trip"/>
 </navigation>

--- a/app/src/main/res/navigation/nav_place.xml
+++ b/app/src/main/res/navigation/nav_place.xml
@@ -18,6 +18,14 @@
         <action
             android:id="@+id/action_aroundPlace_to_placeDetail"
             app:destination="@id/navigation_place_detail" />
+        <action
+            android:id="@+id/action_aroundPlace_to_placeMap"
+            app:destination="@id/navigation_around_place_map" />
     </fragment>
+    <fragment
+        android:id="@+id/navigation_around_place_map"
+        android:name="com.starters.yeogida.presentation.around.AroundPlaceMapFragment"
+        android:label="fragment_around_place_map"
+        tools:layout="@layout/fragment_around_place_map" />
 
 </navigation>


### PR DESCRIPTION
## 💡 관련 이슈
<!--close #이슈넘버-->
close #64 

## 🌱 변경 사항 및 이유
<!--변경사항 적기-->
- 뒤로 가기 구현
- 각 페이지 연결 (nav 변경 등)
- 맨 위로 가기 구현

## ✅ PR Point
<!--리뷰에 중점이 될 포인트 요소들 적기-->
- nav_place에 장소 둘러보기 관련 fragment들이 연결됨에 따라 nav_add_trip에 있던 관련 부분을 삭제했습니다.
- 각 페이지 이동을 navigation을 활용했습니다.

## ❗️ 참고 사항
+ 버튼은 장소 추가 화면이 나온 후에 연결할 수 있어서 제외했습니다.
<!--다른 개발자들이 참고했으면 하는 사항-->

<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
