### PR TITLE
[UI] 여행지 글, 장소 상세 부분 Collapsing Toolbar Layout 관련 디자인 수정

### DIFF
--- a/app/src/main/res/layout/fragment_around_place.xml
+++ b/app/src/main/res/layout/fragment_around_place.xml
@@ -30,6 +30,7 @@
                 app:collapsedTitleTextAppearance="@style/CollapsingToolbar.Collapsed.Title"
                 app:contentScrim="@color/white"
                 app:expandedTitleGravity="right|bottom"
+                app:collapsedTitleGravity="left"
                 app:expandedTitleTextAppearance="@style/CollapsingToolbar.Expanded.Trip.Title"
                 app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
 
@@ -129,9 +130,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
                     android:background="@color/white"
-                    android:backgroundTint="@color/white"
                     android:elevation="0dp"
                     app:contentInsetStart="0dp"
+                    app:contentInsetStartWithNavigation="4dp"
                     app:layout_collapseMode="pin"
                     app:navigationIcon="@drawable/ic_back">
 

--- a/app/src/main/res/layout/fragment_around_place.xml
+++ b/app/src/main/res/layout/fragment_around_place.xml
@@ -30,13 +30,14 @@
                 app:collapsedTitleTextAppearance="@style/CollapsingToolbar.Collapsed.Title"
                 app:contentScrim="@color/white"
                 app:expandedTitleGravity="right|bottom"
-                app:expandedTitleTextAppearance="@style/CollapsingToolbar.Expanded.Title"
+                app:expandedTitleTextAppearance="@style/CollapsingToolbar.Expanded.Trip.Title"
                 app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
 
                 <ImageView
                     android:id="@+id/iv_around_place_trip"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
+                    android:layout_marginTop="?attr/actionBarSize"
                     android:scaleType="centerCrop"
                     app:layout_collapseMode="parallax"
                     tools:src="@drawable/ic_app" />
@@ -134,17 +135,17 @@
                     app:layout_collapseMode="pin"
                     app:navigationIcon="@drawable/ic_back">
 
-                <ImageView
-                    android:id="@+id/iv_around_place_map"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="end"
-                    android:layout_marginEnd="4dp"
-                    android:onClick="@{view::moveToPlaceMap}"
-                    android:padding="12dp"
-                    android:src="@drawable/ic_map" />
+                    <ImageView
+                        android:id="@+id/iv_around_place_map"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end"
+                        android:layout_marginEnd="4dp"
+                        android:onClick="@{view::moveToPlaceMap}"
+                        android:padding="12dp"
+                        android:src="@drawable/ic_map" />
 
-            </androidx.appcompat.widget.Toolbar>
+                </androidx.appcompat.widget.Toolbar>
 
 
             </com.google.android.material.appbar.CollapsingToolbarLayout>
@@ -352,7 +353,7 @@
                         android:gravity="center"
                         android:text="@string/around_place_top"
                         android:textColor="@color/black"
-                        android:textSize="16sp"/>
+                        android:textSize="16sp" />
 
                     <ImageView
                         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_place_detail.xml
+++ b/app/src/main/res/layout/fragment_place_detail.xml
@@ -26,6 +26,7 @@
                 android:id="@+id/layout_collapsing_place_detail"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                app:collapsedTitleGravity="left"
                 app:collapsedTitleTextAppearance="@style/CollapsingToolbar.Collapsed.Title"
                 app:contentScrim="@color/white"
                 app:expandedTitleTextAppearance="@style/CollapsingToolbar.Expanded.Place.Title"
@@ -53,6 +54,8 @@
                     android:id="@+id/tb_place_detail"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    app:contentInsetStart="0dp"
+                    android:elevation="0dp"
                     app:contentInsetStartWithNavigation="4dp"
                     app:layout_collapseMode="pin"
                     app:navigationIcon="@drawable/ic_back" />

--- a/app/src/main/res/layout/fragment_place_detail.xml
+++ b/app/src/main/res/layout/fragment_place_detail.xml
@@ -23,10 +23,14 @@
             android:layout_height="wrap_content">
 
             <com.google.android.material.appbar.CollapsingToolbarLayout
+                android:id="@+id/layout_collapsing_place_detail"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                app:collapsedTitleTextAppearance="@style/CollapsingToolbar.Collapsed.Title"
                 app:contentScrim="@color/white"
-                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+                app:expandedTitleTextAppearance="@style/CollapsingToolbar.Expanded.Place.Title"
+                app:layout_scrollFlags="scroll|exitUntilCollapsed|snap"
+                app:title="@{place.placeName}">
 
                 <androidx.viewpager2.widget.ViewPager2
                     android:id="@+id/viewpager_place_toolbar"
@@ -51,22 +55,7 @@
                     android:layout_height="wrap_content"
                     app:contentInsetStartWithNavigation="4dp"
                     app:layout_collapseMode="pin"
-                    app:navigationIcon="@drawable/ic_back">
-
-                    <TextView
-                        android:id="@+id/tb_place_detail_name"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="10dp"
-                        android:ellipsize="end"
-                        android:fontFamily="@font/noto_sans_medium"
-                        android:maxLines="1"
-                        android:text="@{place.placeName}"
-                        android:textColor="@color/black"
-                        android:textSize="20sp"
-                        tools:text="케이스퀘어 빌딩" />
-
-                </androidx.appcompat.widget.Toolbar>
+                    app:navigationIcon="@drawable/ic_back" />
 
             </com.google.android.material.appbar.CollapsingToolbarLayout>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -26,14 +26,20 @@
         <item name="android:maxHeight">47dip</item>
     </style>
 
-    <!-- CollapsingToolbar Expanded Style -->
-    <style name="CollapsingToolbar.Expanded.Title" parent="@android:style/TextAppearance">
+    <!-- CollapsingToolbar Expanded Title Style -->
+    <style name="CollapsingToolbar.Expanded.Trip.Title" parent="@android:style/TextAppearance">
         <item name="android:textColor">@android:color/white</item>
         <item name="fontFamily">@font/noto_sans_bold</item>
         <item name="android:textSize">24sp</item>
     </style>
 
-    <!-- CollapsingToolbar Collapsed Style -->
+    <style name="CollapsingToolbar.Expanded.Place.Title" parent="@android:style/TextAppearance">
+        <item name="android:textColor">@android:color/transparent</item>
+        <item name="fontFamily">@font/noto_sans_bold</item>
+        <item name="android:textSize">0.1sp</item>
+    </style>
+
+    <!-- CollapsingToolbar Collapsed Title Style -->
     <style name="CollapsingToolbar.Collapsed.Title" parent="@android:style/TextAppearance">
         <item name="android:textColor">@android:color/black</item>
         <item name="android:textSize">20sp</item>


### PR DESCRIPTION
## 💡 관련 이슈
close #39 <!--close #이슈넘버-->

## 🌱 변경 사항 및 이유
- Collapsing Toolbar Layout `Title`이 장소 상세 부분에서 잘 안보일 수 있다고 생각하여 디자인 수정 <!--변경사항 적기-->
- 여행지 게시글(장소 목록) Collapsing Toolbar Layout 배경 이미지 잘리던 부분 marginTop 주어서 해결 
- Collapsing, Expanded Title Style 추가 및 수정
