### PR TITLE
[NETWORK] 장소 태그, 정렬

### DIFF
--- a/app/src/main/java/com/starters/yeogida/data/api/PlaceService.kt
+++ b/app/src/main/java/com/starters/yeogida/data/api/PlaceService.kt
@@ -10,9 +10,10 @@ import retrofit2.http.*
 
 interface PlaceService {
     // 장소 목록
-    @GET("{tripId}/places")
-    fun getPlaceList(
+    @GET("{tripId}/places/{tag}")
+    fun getPlaceTagList(
         @Path("tripId") tripId: Long,
+        @Path("tag") tag: String,
         @Query("condition") condition: String
     ): Call<BaseResponse<PlaceListResponse>>
 


### PR DESCRIPTION
## 💡 관련 이슈
<!--close #이슈넘버-->
close #91 

## 🌱 변경 사항 및 이유
<!--변경사항 적기-->
- 장소 목록 api 추가
- 장소 태그, 정렬 

## ✅ PR Point
<!--리뷰에 중점이 될 포인트 요소들 적기-->
- 태그, 정렬 값은 전역 변수로 선언해 두 가지를 동시에 적용할 수 있도록 함
- 정렬은 bottom sheet값에 따라 적용
- 태그는 chip button에 따라 적용 (단, checkId값이 없으면 태그를 nothing으로 적용)
