### PR TITLE
[FEAT] 여행지 - 장소 간 데이터 전달

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
     id 'kotlin-android-extensions'
+    id 'androidx.navigation.safeargs.kotlin'
 }
 
 android {

--- a/app/src/main/java/com/starters/yeogida/data/api/TripService.kt
+++ b/app/src/main/java/com/starters/yeogida/data/api/TripService.kt
@@ -2,6 +2,7 @@ package com.starters.yeogida.data.api
 
 import com.starters.yeogida.data.remote.response.BaseResponse
 import com.starters.yeogida.data.remote.response.trip.PostTripResponse
+import com.starters.yeogida.data.remote.response.trip.TripInfoResponse
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.Call
@@ -16,4 +17,10 @@ interface TripService {
         @Part imgUrl: MultipartBody.Part,
         @PartMap postTripRequest: HashMap<String, RequestBody>
     ): Call<BaseResponse<PostTripResponse>>
+
+    // 장소 목록 - 여행지 조회
+    @GET("{tripId}/places/tripInfo")
+    fun getTripInfo(
+        @Path("tripId") tripId: Long
+    ): Call<BaseResponse<TripInfoResponse>>
 }

--- a/app/src/main/java/com/starters/yeogida/data/remote/response/trip/PostTripResponse.kt
+++ b/app/src/main/java/com/starters/yeogida/data/remote/response/trip/PostTripResponse.kt
@@ -1,7 +1,8 @@
 package com.starters.yeogida.data.remote.response.trip
 
 data class PostTripResponse(
-    val id: Long,
+    val tripId: Long,
+    val memberId: Long,
     val region: String,
     val title: String,
     val subTitle: String,

--- a/app/src/main/java/com/starters/yeogida/data/remote/response/trip/TripInfoResponse.kt
+++ b/app/src/main/java/com/starters/yeogida/data/remote/response/trip/TripInfoResponse.kt
@@ -1,0 +1,9 @@
+package com.starters.yeogida.data.remote.response.trip
+
+data class TripInfoResponse(
+    val title: String,
+    val subTitle: String,
+    val imgUrl: String,
+    val heartCount: Int,
+    val placeCount: Int
+)

--- a/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
@@ -2,6 +2,7 @@ package com.starters.yeogida.presentation.around
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -24,6 +25,7 @@ class AroundPlaceFragment : Fragment() {
     private val viewModel: AroundPlaceViewModel by viewModels()
     private var sortValue: String = "id"
     private var tagValue: String = "nothing"
+    private var tripId: Long = 0
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -38,7 +40,7 @@ class AroundPlaceFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        // getTripData()
+        getTripData()
         initPlaceList()
         initNavigation()
         initBottomSheet()
@@ -46,6 +48,11 @@ class AroundPlaceFragment : Fragment() {
         with(binding.layoutCollapsingAroundPlace) {
             title = "일이삼사오육칠팔구십"
         }
+    }
+
+    private fun getTripData() {
+        val args = requireActivity().intent?.extras?.let { AroundPlaceFragmentArgs.fromBundle(it) }
+        args?.tripId?.let { tripId = it }
     }
 
     private fun initBottomSheet() {
@@ -70,13 +77,13 @@ class AroundPlaceFragment : Fragment() {
         val aroundPlaceAdapter = AroundPlaceAdapter(viewModel)
         binding.rvAroundPlace.adapter = aroundPlaceAdapter
         YeogidaClient.placeService.getPlaceTagList(
-            2,
+            tripId,
             tagValue,
             sortValue
         ).customEnqueue(
             onSuccess = { responseData ->
                 if (responseData.code == 200) {
-                    if (sortValue.isEmpty() && responseData.data?.placeList?.isEmpty() == true) {
+                    if (sortValue == "id" && responseData.data?.placeList?.isEmpty() == true) {
                         with(binding) {
                             rvAroundPlace.visibility = View.GONE
                             layoutAroundPlaceTop.visibility = View.GONE

--- a/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
@@ -2,7 +2,6 @@ package com.starters.yeogida.presentation.around
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -40,19 +39,36 @@ class AroundPlaceFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        getTripData()
+        getTripId()
         initPlaceList()
         initNavigation()
         initBottomSheet()
         initChipClickListener()
-        with(binding.layoutCollapsingAroundPlace) {
-            title = "일이삼사오육칠팔구십"
-        }
     }
 
-    private fun getTripData() {
+    private fun getTripId() {
         val args = requireActivity().intent?.extras?.let { AroundPlaceFragmentArgs.fromBundle(it) }
         args?.tripId?.let { tripId = it }
+        initTripData()
+    }
+
+    private fun initTripData() {
+        YeogidaClient.tripService.getTripInfo(
+            tripId
+        ).customEnqueue(
+            onSuccess = {
+                if (it.code == 200) {
+                    with(binding) {
+                        layoutCollapsingAroundPlace.title = it.data?.title
+                        GlideApp.with(ivAroundPlaceTrip)
+                            .load(it.data?.imgUrl)
+                            .into(ivAroundPlaceTrip)
+                        tvAroundPlacePlaceCount.text = it.data?.placeCount.toString()
+                        tvAroundPlaceTripLikeCount.text = it.data?.heartCount.toString()
+                    }
+                }
+            }
+        )
     }
 
     private fun initBottomSheet() {
@@ -100,10 +116,6 @@ class AroundPlaceFragment : Fragment() {
                 }
             }
         )
-
-        GlideApp.with(binding.ivAroundPlaceTrip)
-            .load("https://cdn.pixabay.com/photo/2018/02/17/13/08/the-body-of-water-3159920__480.jpg")
-            .into(binding.ivAroundPlaceTrip)
     }
 
     private fun initNavigation() {

--- a/app/src/main/java/com/starters/yeogida/presentation/place/PlaceActivity.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/place/PlaceActivity.kt
@@ -5,12 +5,17 @@ import androidx.appcompat.app.AppCompatActivity
 import com.starters.yeogida.databinding.ActivityPlaceBinding
 
 class PlaceActivity : AppCompatActivity() {
-
     private lateinit var binding: ActivityPlaceBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityPlaceBinding.inflate(layoutInflater)
+        getTripId()
         setContentView(binding.root)
+    }
+
+    private fun getTripId() {
+        val tripId = intent.getLongExtra("tripId", 0)
+        intent.putExtra("tripId", tripId)
     }
 }

--- a/app/src/main/java/com/starters/yeogida/presentation/trip/AddTripFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/trip/AddTripFragment.kt
@@ -128,8 +128,9 @@ class AddTripFragment : Fragment() {
             }
         }
 
-    private fun moveToAroundPlace() {
+    private fun moveToAroundPlace(tripId: Long) {
         val intent = Intent(activity, PlaceActivity::class.java)
+        intent.putExtra("tripId", tripId)
         startActivity(intent)
         (activity as AddTripActivity).finish()
     }
@@ -142,7 +143,7 @@ class AddTripFragment : Fragment() {
         val textHashMap = hashMapOf<String, RequestBody>()
 
         with(binding) {
-            val regionRequestBody = tvAddTripRegion.toString().toPlainRequestBody()
+            val regionRequestBody = tvAddTripRegion.text.toString().toPlainRequestBody()
             val titleRequestBody = etAddTripName.text.toString().toPlainRequestBody()
             val subTitleRequestBody = etAddTripSubtitle.text.toString().toPlainRequestBody()
 
@@ -164,9 +165,9 @@ class AddTripFragment : Fragment() {
                 tripImg,
                 textHashMap
             ).customEnqueue(
-                onSuccess = {
-                    if (it.code == 201) {
-                        moveToAroundPlace()
+                onSuccess = { responseData ->
+                    if (responseData.code == 201) {
+                        responseData.data?.tripId?.let { tripId -> moveToAroundPlace(tripId) }
                     }
                 }
             )

--- a/app/src/main/res/navigation/nav_place.xml
+++ b/app/src/main/res/navigation/nav_place.xml
@@ -21,6 +21,8 @@
         <action
             android:id="@+id/action_aroundPlace_to_placeMap"
             app:destination="@id/navigation_around_place_map" />
+        <argument android:name="tripId"
+            app:argType="long"/>
     </fragment>
     <fragment
         android:id="@+id/navigation_around_place_map"

--- a/build.gradle
+++ b/build.gradle
@@ -3,4 +3,5 @@ plugins {
     id 'com.android.application' version '7.3.1' apply false
     id 'com.android.library' version '7.3.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
+    id 'androidx.navigation.safeargs.kotlin' version '2.5.3' apply false
 }


### PR DESCRIPTION
## 💡 관련 이슈
<!--close #이슈넘버-->
close #92 

## 🌱 변경 사항 및 이유
<!--변경사항 적기-->
- tripId 전달 받아서 장소 둘러보기 상단 여행지 정보에 사용
- 여행지 조회 api 추가

## ✅ PR Point
<!--리뷰에 중점이 될 포인트 요소들 적기-->
- safe args를 이용해 데이터 전달

## ❗️ 참고 사항
- 현재 여행지 추가 후에 tripId만 받는 상태라 다른 화면에서 조회 불가
<!--다른 개발자들이 참고했으면 하는 사항-->

<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
