### PR TITLE
[NETWORK] 장소 지도로 보기 

### DIFF
--- a/app/src/main/java/com/starters/yeogida/data/api/PlaceService.kt
+++ b/app/src/main/java/com/starters/yeogida/data/api/PlaceService.kt
@@ -6,6 +6,7 @@ import com.starters.yeogida.data.remote.response.BaseResponse
 import com.starters.yeogida.data.remote.response.place.AddCommentResponse
 import com.starters.yeogida.data.remote.response.place.PlaceDetailResponse
 import com.starters.yeogida.data.remote.response.place.PlaceListResponse
+import com.starters.yeogida.data.remote.response.place.PlaceMapListResponse
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.http.*
@@ -18,6 +19,18 @@ interface PlaceService {
         @Path("tag") tag: String,
         @Query("condition") condition: String
     ): Call<BaseResponse<PlaceListResponse>>
+
+    // 장소 지도로 보기
+    @GET("{tripId}/places/inMap")
+    fun getPlaceMapList(
+        @Path("tripId") tripId: Long
+    ): Call<BaseResponse<PlaceMapListResponse>>
+
+    // 장소 상세
+    @GET("places/{placeId}")
+    suspend fun getPlaceDetail(
+        @Path("placeId") placeId: Long
+    ): Response<BaseResponse<PlaceDetailResponse>>
 
     // 댓글 목록 (작성순)
     @GET("{placeId}/comments/idAsc")
@@ -39,9 +52,4 @@ interface PlaceService {
         @Header("Authorization") token: String,
         @Path("commentId") commentId: Long
     ): Call<BaseResponse<Any>>
-
-    @GET("places/{placeId}")
-    suspend fun getPlaceDetail(
-        @Path("placeId") placeId: Long
-    ): Response<BaseResponse<PlaceDetailResponse>>
 }

--- a/app/src/main/java/com/starters/yeogida/data/local/PlaceMapData.kt
+++ b/app/src/main/java/com/starters/yeogida/data/local/PlaceMapData.kt
@@ -3,7 +3,7 @@ package com.starters.yeogida.data.local
 data class PlaceMapData(
     val placeThumbnail: String,
     val placeName: String,
-    val star: Double,
+    val star: Float,
     val comment: Int,
     val tag: String,
     val address: String

--- a/app/src/main/java/com/starters/yeogida/data/remote/response/place/PlaceMapListResponse.kt
+++ b/app/src/main/java/com/starters/yeogida/data/remote/response/place/PlaceMapListResponse.kt
@@ -1,0 +1,19 @@
+package com.starters.yeogida.data.remote.response.place
+
+data class PlaceMapListResponse(
+    val meanLat: Double,
+    val meanLng: Double,
+    val placeList: List<PlaceMapList>
+)
+
+data class PlaceMapList(
+    val placeId: Long,
+    val title: String,
+    val address: String,
+    val star: Float,
+    val commentCount: Int,
+    val imgUrl: String,
+    val tag: String,
+    val latitude: Double,
+    val longitude: Double
+)

--- a/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
@@ -108,6 +108,7 @@ class AroundPlaceFragment : Fragment() {
                             rvAroundPlace.visibility = View.GONE
                             layoutAroundPlaceTop.visibility = View.GONE
                             layoutAroundPlaceEmpty.visibility = View.VISIBLE
+                            ivAroundPlaceMap.visibility = View.INVISIBLE
                         }
                     } else {
                         responseData.data?.let { data ->

--- a/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceFragment.kt
@@ -155,7 +155,7 @@ class AroundPlaceFragment : Fragment() {
     }
 
     fun moveToPlaceMap(view: View) {
-        findNavController().navigate(R.id.action_aroundPlace_to_placeMap)
+        findNavController().navigate(R.id.action_aroundPlace_to_placeMap, bundleOf("tripId" to tripId))
     }
 
     fun moveToAddPlace(view: View) {

--- a/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceMapFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceMapFragment.kt
@@ -63,13 +63,13 @@ class AroundPlaceMapFragment : Fragment(), OnMapReadyCallback, GoogleMap.OnMarke
             onSuccess = {
                 if (it.code == 200) {
                     // 장소들의 중심 좌표로 카메라 이동
-                    it.data?.let { response -> initMapCamera(response.meanLat, it.data.meanLng) }
+                    it.data?.let { data -> initMapCamera(data.meanLat, data.meanLng) }
                     mPlaceMapList = it.data?.placeList ?: arrayListOf()
 
                     // 위도 경도 리스트 만들기
                     val locationArrayList = arrayListOf<LatLng>()
                     for (i in 0 until (it.data?.placeList?.size ?: 0)) {
-                        val mLatLng = it.data?.placeList?.get(i)?.let { it1 -> LatLng(it1.latitude, it1.longitude) }
+                        val mLatLng = it.data?.placeList?.get(i)?.let { place -> LatLng(place.latitude, place.longitude) }
                         if (mLatLng != null) {
                             locationArrayList.add(mLatLng)
                         }

--- a/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceMapFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/around/AroundPlaceMapFragment.kt
@@ -85,7 +85,7 @@ class AroundPlaceMapFragment : Fragment(), OnMapReadyCallback, GoogleMap.OnMarke
     private fun initMapCamera(latitude: Double, longitude: Double) {
         val mLatLng = LatLng(latitude, longitude)
         mMap.moveCamera(CameraUpdateFactory.newLatLng(mLatLng))
-        mMap.moveCamera(CameraUpdateFactory.zoomTo(15f))
+        mMap.moveCamera(CameraUpdateFactory.zoomTo(11f))
     }
 
     private fun initNavigation() {

--- a/app/src/main/java/com/starters/yeogida/presentation/around/PlaceMapBottomSheetFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/around/PlaceMapBottomSheetFragment.kt
@@ -8,9 +8,10 @@ import androidx.databinding.DataBindingUtil
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.starters.yeogida.R
 import com.starters.yeogida.data.local.PlaceMapData
+import com.starters.yeogida.data.remote.response.place.PlaceMapList
 import com.starters.yeogida.databinding.FragmentPlaceMapBottomSheetBinding
 
-class PlaceMapBottomSheetFragment : BottomSheetDialogFragment() {
+class PlaceMapBottomSheetFragment(private val placeList: PlaceMapList) : BottomSheetDialogFragment() {
     private lateinit var binding: FragmentPlaceMapBottomSheetBinding
 
     override fun onCreateView(
@@ -26,18 +27,17 @@ class PlaceMapBottomSheetFragment : BottomSheetDialogFragment() {
         )
 
         initAdapter()
-
         return binding.root
     }
 
     private fun initAdapter() {
         binding.place = PlaceMapData(
-            "https://cdn.pixabay.com/photo/2016/11/12/22/42/santa-claus-1819933_1280.jpg",
-            "산타마을",
-            3.5,
-            4,
-            "쇼핑",
-            "서울시 땡땡구 123 1"
+            placeList.imgUrl,
+            placeList.title,
+            placeList.star,
+            placeList.commentCount,
+            placeList.tag,
+            placeList.address
         )
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
<!--close #이슈넘버-->
close #51 

## 🌱 변경 사항 및 이유
<!--변경사항 적기-->
- 장소 지도로 보기 api 연결
- 장소 다중 마커 찍기
- 장소 마커 바텀 시트 연결

## ✅ PR Point
<!--리뷰에 중점이 될 포인트 요소들 적기-->
- 서버에서 전달 받은 데이터로 리스트를 만들어서 마커를 생성
- 마커 데이터는 onMarkerClick의 p0을 이용
- bottom sheet fragment에 장소 데이터를 넘겨서 데이터를 보여줌

## ❗️ 참고 사항
- 초기 카메라 중심 좌표의 줌 배율은 실제 데이터가 나오면 조정하겠습니다.
- tripId 부분을 연결했지만, 서버 데이터가 없어 확인하지 못했습니다. (더미 아이디로는 확인했습니다.)
<!--다른 개발자들이 참고했으면 하는 사항-->

<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
