### PR TITLE
[FEAT] 장소 지도로 보기

### DIFF
--- a/app/src/main/java/com/starters/yeogida/presentation/around/PlaceMapBottomSheetFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/around/PlaceMapBottomSheetFragment.kt
@@ -4,7 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
 import androidx.databinding.DataBindingUtil
+import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.starters.yeogida.R
 import com.starters.yeogida.data.local.PlaceMapData
@@ -27,6 +29,8 @@ class PlaceMapBottomSheetFragment(private val placeList: PlaceMapList) : BottomS
         )
 
         initAdapter()
+        binding.view = this
+
         return binding.root
     }
 
@@ -39,5 +43,10 @@ class PlaceMapBottomSheetFragment(private val placeList: PlaceMapList) : BottomS
             placeList.tag,
             placeList.address
         )
+    }
+
+    fun moveToDetail(view: View) {
+        findNavController().navigate(R.id.action_placeMap_to_placeDetail, bundleOf("placeId" to placeList.placeId))
+        dismiss()
     }
 }

--- a/app/src/main/java/com/starters/yeogida/presentation/place/AddPlaceFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/place/AddPlaceFragment.kt
@@ -530,7 +530,7 @@ class AddPlaceFragment : Fragment(), PlaceImageClickListener {
             setPositiveBtn("확인") {
                 dismissDialog()
                 requireContext().shortToast("글 작성을 취소하였습니다")
-                // finish()
+                findNavController().navigateUp()
             }
             setNegativeBtn("닫기") {
                 dismissDialog()

--- a/app/src/main/java/com/starters/yeogida/presentation/place/PlaceDetailFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/place/PlaceDetailFragment.kt
@@ -87,6 +87,9 @@ class PlaceDetailFragment : Fragment() {
                         tripId = data.tripId
                         withContext(Dispatchers.Main) {
                             binding.place = data
+                            if (data.placeImgs[0].imgUrl == "https://yeogida-bucket.s3.ap-northeast-2.amazonaws.com/default_place.png") {
+                                binding.viewpagerPlaceToolbar.visibility = View.GONE
+                            }
                             setToolbar(data.placeImgs)
                         }
                     }

--- a/app/src/main/res/layout/fragment_place_map_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_place_map_bottom_sheet.xml
@@ -8,12 +8,16 @@
         <variable
             name="place"
             type="com.starters.yeogida.data.local.PlaceMapData" />
+        <variable
+            name="view"
+            type="com.starters.yeogida.presentation.around.PlaceMapBottomSheetFragment" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
+        android:onClick="@{view::moveToDetail}"
         android:background="@drawable/rectangle_fill_white_20"
         tools:context=".presentation.around.PlaceMapBottomSheetFragment">
 

--- a/app/src/main/res/navigation/nav_place.xml
+++ b/app/src/main/res/navigation/nav_place.xml
@@ -31,7 +31,11 @@
         android:id="@+id/navigation_around_place_map"
         android:name="com.starters.yeogida.presentation.around.AroundPlaceMapFragment"
         android:label="fragment_around_place_map"
-        tools:layout="@layout/fragment_around_place_map" />
+        tools:layout="@layout/fragment_around_place_map" >
+        <action
+            android:id="@+id/action_placeMap_to_placeDetail"
+            app:destination="@id/navigation_place_detail" />
+    </fragment>
     <fragment
         android:id="@+id/navigation_add_place"
         android:name="com.starters.yeogida.presentation.place.AddPlaceFragment"


### PR DESCRIPTION
## 💡 관련 이슈
<!--close #이슈넘버-->
close #117 

## 🌱 변경 사항 및 이유
<!--변경사항 적기-->
- 마커 클릭 시 나타나는 바텀시트 클릭 시 해당 장소의 상세 화면으로 이동
- 장소 추가 취소 다이얼로그의 확인 처리
- 장소 상세의 디폴트 이미지 처리

## ❗️ 참고 사항
- fragment 재생성으로 상세에서 뒤로 가기를 누르면 전 화면이 없어집니다. 이에 대한 처리는 추후에 시도하겠습니다.
- 마지막 두 커밋은 해당 pr과 관련이 없습니다.
<!--다른 개발자들이 참고했으면 하는 사항-->

<!--사진올리는 양식임 <img src = "이 자리에 image url넣기" width = 200> -->
