### PR TITLE
[FEAT] 알림 설정

### DIFF
--- a/app/src/main/java/com/starters/yeogida/MainActivity.kt
+++ b/app/src/main/java/com/starters/yeogida/MainActivity.kt
@@ -102,20 +102,19 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun checkNotification() {
-        val dataStore = YeogidaApplication.getInstance().getDataStore()
-
         if (NotificationManagerCompat.from(context).areNotificationsEnabled()) {
-            CoroutineScope(Dispatchers.IO).launch {
-                dataStore.saveNotificationLikeIsAllow(true)
-                dataStore.saveNotificationFollowIsAllow(true)
-                dataStore.saveNotificationCommentIsAllow(true)
-            }
+            saveNotificationAllow(like = true, follow = true, comment = true)
         } else {
-            CoroutineScope(Dispatchers.IO).launch {
-                dataStore.saveNotificationLikeIsAllow(false)
-                dataStore.saveNotificationFollowIsAllow(false)
-                dataStore.saveNotificationCommentIsAllow(false)
-            }
+            saveNotificationAllow(like = false, follow = false, comment = false)
+        }
+    }
+
+    private fun saveNotificationAllow(like: Boolean, follow: Boolean, comment: Boolean) {
+        val dataStore = YeogidaApplication.getInstance().getDataStore()
+        CoroutineScope(Dispatchers.IO).launch {
+            dataStore.saveNotificationLikeIsAllow(like)
+            dataStore.saveNotificationFollowIsAllow(follow)
+            dataStore.saveNotificationCommentIsAllow(comment)
         }
     }
 }

--- a/app/src/main/java/com/starters/yeogida/MainActivity.kt
+++ b/app/src/main/java/com/starters/yeogida/MainActivity.kt
@@ -1,13 +1,22 @@
 package com.starters.yeogida
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.NotificationManagerCompat
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
 import com.starters.yeogida.databinding.ActivityMainBinding
 import com.starters.yeogida.presentation.place.PlaceActivity
 import com.starters.yeogida.presentation.user.profile.UserProfileActivity
+import gun0912.tedimagepicker.util.ToastUtil.context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
@@ -18,8 +27,16 @@ class MainActivity : AppCompatActivity() {
 
         initBottomNavigation()
         initNotification()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            createNotificationChannel(this)
+        }
 
         setContentView(binding.root)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        checkNotification()
     }
 
     private fun initBottomNavigation() {
@@ -72,6 +89,33 @@ class MainActivity : AppCompatActivity() {
                 startActivity(intent)
             }
             else -> {}
+        }
+    }
+
+    private fun createNotificationChannel(context: Context) {
+        val name = "YeoGidia"
+        val importance = NotificationManager.IMPORTANCE_DEFAULT
+        val channelId = "${context.packageName}-$name"
+        val channel = NotificationChannel(channelId, name, importance)
+        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(channel)
+    }
+
+    private fun checkNotification() {
+        val dataStore = YeogidaApplication.getInstance().getDataStore()
+
+        if (NotificationManagerCompat.from(context).areNotificationsEnabled()) {
+            CoroutineScope(Dispatchers.IO).launch {
+                dataStore.saveNotificationLikeIsAllow(true)
+                dataStore.saveNotificationFollowIsAllow(true)
+                dataStore.saveNotificationCommentIsAllow(true)
+            }
+        } else {
+            CoroutineScope(Dispatchers.IO).launch {
+                dataStore.saveNotificationLikeIsAllow(false)
+                dataStore.saveNotificationFollowIsAllow(false)
+                dataStore.saveNotificationCommentIsAllow(false)
+            }
         }
     }
 }

--- a/app/src/main/java/com/starters/yeogida/YeogidaDataStore.kt
+++ b/app/src/main/java/com/starters/yeogida/YeogidaDataStore.kt
@@ -19,6 +19,11 @@ class YeogidaDataStore(private val context: Context) {
         booleanPreferencesKey("IS_IMAGE_PERMISSION_REJECTED")
     private val MEMBER_ID = longPreferencesKey("MEMBER_ID")
 
+    // 알림
+    private val NOTIFICATION_IS_LIKE = booleanPreferencesKey("NOTIFICATION_IS_LIKE")
+    private val NOTIFICATION_IS_FOLLOW = booleanPreferencesKey("NOTIFICATION_IS_FOLLOW")
+    private val NOTIFICATION_IS_COMMENT = booleanPreferencesKey("NOTIFICATION_IS_COMMENT")
+
     val userAccessToken: Flow<String> = context.userDataStore.data
         .catch { exception ->
             if (exception is IOException) {
@@ -91,6 +96,42 @@ class YeogidaDataStore(private val context: Context) {
             userPrefs[MEMBER_ID] ?: 0
         }
 
+    val notificationLikeIsAllow: Flow<Boolean> = context.userDataStore.data
+        .catch { exception ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { userPrefs ->
+            userPrefs[NOTIFICATION_IS_LIKE] ?: true
+        }
+
+    val notificationFollowIsAllow: Flow<Boolean> = context.userDataStore.data
+        .catch { exception ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { userPrefs ->
+            userPrefs[NOTIFICATION_IS_FOLLOW] ?: true
+        }
+
+    val notificationCommentIsAllow: Flow<Boolean> = context.userDataStore.data
+        .catch { exception ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { userPrefs ->
+            userPrefs[NOTIFICATION_IS_COMMENT] ?: true
+        }
+
     private suspend fun saveAccessToken(accessToken: String) {
         context.userDataStore.edit { userPrefs ->
             userPrefs[USER_ACCESS_TOKEN_KEY] = accessToken
@@ -142,6 +183,24 @@ class YeogidaDataStore(private val context: Context) {
     suspend fun saveIsImgPermissionRejected(isRejected: Boolean) {
         context.userDataStore.edit { userPrefs ->
             userPrefs[IMAGE_PERMISSION_IS_REJECTED_KEY] = isRejected
+        }
+    }
+
+    suspend fun saveNotificationLikeIsAllow(isAllow: Boolean) {
+        context.userDataStore.edit { userPrefs ->
+            userPrefs[NOTIFICATION_IS_LIKE] = isAllow
+        }
+    }
+
+    suspend fun saveNotificationFollowIsAllow(isAllow: Boolean) {
+        context.userDataStore.edit { userPrefs ->
+            userPrefs[NOTIFICATION_IS_FOLLOW] = isAllow
+        }
+    }
+
+    suspend fun saveNotificationCommentIsAllow(isAllow: Boolean) {
+        context.userDataStore.edit { userPrefs ->
+            userPrefs[NOTIFICATION_IS_COMMENT] = isAllow
         }
     }
 

--- a/app/src/main/java/com/starters/yeogida/presentation/mypage/NotificationSettingFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/mypage/NotificationSettingFragment.kt
@@ -1,60 +1,54 @@
 package com.starters.yeogida.presentation.mypage
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.starters.yeogida.R
+import androidx.fragment.app.Fragment
+import com.starters.yeogida.databinding.FragmentNotificationSettingBinding
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [NotificationSettingFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class NotificationSettingFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
+    private lateinit var binding: FragmentNotificationSettingBinding
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = FragmentNotificationSettingBinding.inflate(inflater, container, false)
+        binding.view = this
+        return binding.root
+    }
+
+    // 각 알림 switch check 변경 시
+    fun changeSwitch(view: View) {
+        with(binding) {
+            // 각 알림 switch check를 모두 true 변경 시
+            if (switchNotificationComment.isChecked && switchNotificationLike.isChecked && switchNotificationFollow.isChecked) {
+                switchNotificationAll.isChecked = true
+            }
+
+            // 각 알림 switch check를 모두 false로 변경 시
+            if (!switchNotificationComment.isChecked || !switchNotificationLike.isChecked || !switchNotificationFollow.isChecked) {
+                switchNotificationAll.isChecked = false
+            }
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_notification_setting, container, false)
+    // 전체 알림 switch 변경 시
+    fun changeSwitchAll(view: View) {
+        if (binding.switchNotificationAll.isChecked) {
+            isCheckedNotification(b1 = true, b2 = true, b3 = true)
+        } else {
+            isCheckedNotification(b1 = false, b2 = false, b3 = false)
+        }
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment NotificationSettingFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            NotificationSettingFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
-            }
+    private fun isCheckedNotification(b1: Boolean, b2: Boolean, b3: Boolean) {
+        with(binding) {
+            switchNotificationComment.isChecked = b1
+            switchNotificationLike.isChecked = b2
+            switchNotificationFollow.isChecked = b3
+        }
     }
 }

--- a/app/src/main/java/com/starters/yeogida/presentation/mypage/NotificationSettingFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/mypage/NotificationSettingFragment.kt
@@ -67,19 +67,19 @@ class NotificationSettingFragment : Fragment() {
     // 전체 알림 switch 변경 시
     fun changeSwitchAll(view: View) {
         if (binding.switchNotificationAll.isChecked) {
-            isCheckedNotification(b1 = true, b2 = true, b3 = true)
+            isCheckedNotification(like = true, follow = true, comment = true)
             saveNotification(like = true, follow = true, comment = true)
         } else {
-            isCheckedNotification(b1 = false, b2 = false, b3 = false)
+            isCheckedNotification(like = false, follow = false, comment = false)
             saveNotification(like = false, follow = false, comment = false)
         }
     }
 
-    private fun isCheckedNotification(b1: Boolean, b2: Boolean, b3: Boolean) {
+    private fun isCheckedNotification(like: Boolean, follow: Boolean, comment: Boolean) {
         with(binding) {
-            switchNotificationComment.isChecked = b1
-            switchNotificationLike.isChecked = b2
-            switchNotificationFollow.isChecked = b3
+            switchNotificationLike.isChecked = like
+            switchNotificationFollow.isChecked = follow
+            switchNotificationComment.isChecked = comment
         }
     }
 

--- a/app/src/main/java/com/starters/yeogida/presentation/mypage/NotificationSettingFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/mypage/NotificationSettingFragment.kt
@@ -6,10 +6,16 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import com.starters.yeogida.YeogidaApplication
 import com.starters.yeogida.databinding.FragmentNotificationSettingBinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
 class NotificationSettingFragment : Fragment() {
     private lateinit var binding: FragmentNotificationSettingBinding
+    private val dataStore = YeogidaApplication.getInstance().getDataStore()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -23,10 +29,25 @@ class NotificationSettingFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initSwitchChecked()
         initClickListener()
     }
 
-    // 각 알림 switch check 변경 시
+    private fun initSwitchChecked() {
+        CoroutineScope(Dispatchers.IO).launch {
+            with(binding) {
+                switchNotificationFollow.isChecked = dataStore.notificationFollowIsAllow.first()
+                switchNotificationLike.isChecked = dataStore.notificationLikeIsAllow.first()
+                switchNotificationComment.isChecked = dataStore.notificationCommentIsAllow.first()
+
+                if (switchNotificationComment.isChecked && switchNotificationLike.isChecked && switchNotificationFollow.isChecked) {
+                    switchNotificationAll.isChecked = true
+                }
+            }
+        }
+    }
+
+// 각 알림 switch check 변경 시
     fun changeSwitch(view: View) {
         with(binding) {
             // 각 알림 switch check를 모두 true 변경 시
@@ -34,10 +55,12 @@ class NotificationSettingFragment : Fragment() {
                 switchNotificationAll.isChecked = true
             }
 
-            // 각 알림 switch check를 모두 false로 변경 시
+            // 각 알림 switch check 중 false로 변경 시
             if (!switchNotificationComment.isChecked || !switchNotificationLike.isChecked || !switchNotificationFollow.isChecked) {
                 switchNotificationAll.isChecked = false
             }
+
+            saveNotification(like = switchNotificationLike.isChecked, follow = switchNotificationFollow.isChecked, comment = switchNotificationComment.isChecked)
         }
     }
 
@@ -45,8 +68,10 @@ class NotificationSettingFragment : Fragment() {
     fun changeSwitchAll(view: View) {
         if (binding.switchNotificationAll.isChecked) {
             isCheckedNotification(b1 = true, b2 = true, b3 = true)
+            saveNotification(like = true, follow = true, comment = true)
         } else {
             isCheckedNotification(b1 = false, b2 = false, b3 = false)
+            saveNotification(like = false, follow = false, comment = false)
         }
     }
 
@@ -55,6 +80,14 @@ class NotificationSettingFragment : Fragment() {
             switchNotificationComment.isChecked = b1
             switchNotificationLike.isChecked = b2
             switchNotificationFollow.isChecked = b3
+        }
+    }
+
+    private fun saveNotification(like: Boolean, follow: Boolean, comment: Boolean) {
+        CoroutineScope(Dispatchers.IO).launch {
+            dataStore.saveNotificationLikeIsAllow(like)
+            dataStore.saveNotificationFollowIsAllow(follow)
+            dataStore.saveNotificationCommentIsAllow(comment)
         }
     }
 

--- a/app/src/main/java/com/starters/yeogida/presentation/mypage/NotificationSettingFragment.kt
+++ b/app/src/main/java/com/starters/yeogida/presentation/mypage/NotificationSettingFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import com.starters.yeogida.databinding.FragmentNotificationSettingBinding
 
 class NotificationSettingFragment : Fragment() {
@@ -18,6 +19,11 @@ class NotificationSettingFragment : Fragment() {
         binding = FragmentNotificationSettingBinding.inflate(inflater, container, false)
         binding.view = this
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initClickListener()
     }
 
     // 각 알림 switch check 변경 시
@@ -49,6 +55,12 @@ class NotificationSettingFragment : Fragment() {
             switchNotificationComment.isChecked = b1
             switchNotificationLike.isChecked = b2
             switchNotificationFollow.isChecked = b3
+        }
+    }
+
+    private fun initClickListener() {
+        binding.tbNotificationSetting.setNavigationOnClickListener {
+            findNavController().navigateUp()
         }
     }
 }

--- a/app/src/main/res/layout/fragment_notification_setting.xml
+++ b/app/src/main/res/layout/fragment_notification_setting.xml
@@ -4,6 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <variable
+            name="view"
+            type="com.starters.yeogida.presentation.mypage.NotificationSettingFragment" />
 
     </data>
 
@@ -36,15 +39,6 @@
         </androidx.appcompat.widget.Toolbar>
 
         <View
-            android:id="@+id/view3"
-            android:layout_width="wrap_content"
-            android:layout_height="1dp"
-            android:background="@color/gray_300"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_setting_alarm" />
-
-        <View
             android:id="@+id/view9"
             android:layout_width="wrap_content"
             android:layout_height="1dp"
@@ -54,7 +48,7 @@
             app:layout_constraintTop_toBottomOf="@id/tb_notification_setting" />
 
         <LinearLayout
-            android:id="@+id/layout_setting_alarm"
+            android:id="@+id/layout_notification_all"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
@@ -75,11 +69,12 @@
                 android:textSize="16sp" />
 
             <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/switch_notification_all"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_marginEnd="16dp"
-                android:checked="true"
+                android:onClick="@{view::changeSwitchAll}"
                 android:theme="@style/ColorSwitchStyle" />
 
         </LinearLayout>
@@ -91,10 +86,10 @@
             android:background="@color/gray_300"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_setting_alarm" />
+            app:layout_constraintTop_toBottomOf="@id/layout_notification_all" />
 
         <LinearLayout
-            android:id="@+id/layout_setting_notice"
+            android:id="@+id/layout_notification_like"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
@@ -115,10 +110,12 @@
                 android:textSize="16sp" />
 
             <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/switch_notification_like"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_marginEnd="16dp"
+                android:onClick="@{view::changeSwitch}"
                 android:theme="@style/ColorSwitchStyle" />
 
         </LinearLayout>
@@ -130,10 +127,10 @@
             android:background="@color/gray_300"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_setting_notice" />
+            app:layout_constraintTop_toBottomOf="@id/layout_notification_like" />
 
         <LinearLayout
-            android:id="@+id/layout_setting_center"
+            android:id="@+id/layout_notification_follow"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
@@ -154,10 +151,12 @@
                 android:textSize="16sp" />
 
             <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/switch_notification_follow"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_marginEnd="16dp"
+                android:onClick="@{view::changeSwitch}"
                 android:theme="@style/ColorSwitchStyle" />
 
         </LinearLayout>
@@ -169,10 +168,10 @@
             android:background="@color/gray_300"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_setting_center" />
+            app:layout_constraintTop_toBottomOf="@id/layout_notification_follow" />
 
         <LinearLayout
-            android:id="@+id/layout_setting_logout"
+            android:id="@+id/layout_notification_comment"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
@@ -193,10 +192,12 @@
                 android:textSize="16sp" />
 
             <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/switch_notification_comment"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_marginEnd="16dp"
+                android:onClick="@{view::changeSwitch}"
                 android:theme="@style/ColorSwitchStyle" />
 
         </LinearLayout>
@@ -208,7 +209,7 @@
             android:background="@color/gray_300"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layout_setting_logout" />
+            app:layout_constraintTop_toBottomOf="@id/layout_notification_comment" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## 💡 관련 이슈
<!--close #이슈넘버-->
close #149 

## 🌱 변경 사항 및 이유
<!--변경사항 적기-->
- 전체 알림과 개별 알림 각각 switch check 상태에 따른 isCheck 변경
- 뒤로 가기 
- 알림 여부 data store에 저장
- 개별 알림 상태에 따른 알림 여부
- Android13 알림 권한 처리

## ✅ PR Point
<!--리뷰에 중점이 될 포인트 요소들 적기-->
- Android 13일 때 알림 권한은 MainActivity에서 처리하도록 했습니다.
- data store에 팔로우 알림 여부, 좋아요 알림 여부, 댓글 알림 여부를 저장했습니다.
- FirebaseMessagingService에서 받는 type에 따라 알림 권한 여부 확인 후 알림을 표시하도록 했습니다.
